### PR TITLE
Fix drive list disk size and free space retrieval

### DIFF
--- a/drivewitness.py
+++ b/drivewitness.py
@@ -184,7 +184,7 @@ if __name__ == "__main__":
                 drive = f"{letter}:\\"
                 try:
                     volume_info = win32api.GetVolumeInformation(drive)
-                    total_bytes, free_bytes = win32file.GetDiskFreeSpaceEx(drive)[:2]
+                    _, total_bytes, free_bytes = win32file.GetDiskFreeSpaceEx(drive)
                     drives.append({'path': drive, 'label': volume_info[0],
                                    'fs_type': volume_info[4], 'serial': hex(volume_info[1]),
                                    'total': total_bytes, 'free': free_bytes})


### PR DESCRIPTION
## Summary
- correctly parse total/free bytes from `GetDiskFreeSpaceEx`

## Testing
- `python -m py_compile drivewitness.py`
- `python drivewitness.py --list` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6858756ba83c8323948b20c18c9f8b3c